### PR TITLE
Assessment for Event-B and Rodin added

### DIFF
--- a/T7.1/O7.1.3_O7.1.7/eventB.tex
+++ b/T7.1/O7.1.3_O7.1.7/eventB.tex
@@ -73,7 +73,7 @@ System Analysis & 3 & 3 & 3 &  \\
 \hline
 Sub-system formal design & 3 & 3 & 3 & \\
 \hline
-Software design & 2 & 2 & 1 & \\
+Software design & 2 & 2 & 2 & \\
 \hline
 Software code generation & 1 & 1 & 1 & \\
 \hline
@@ -102,9 +102,9 @@ Code generation & 1 & 1 & 1 & \\
 \hline
 Verification & 3 & 3 & 3 & \\
 \hline
-Validation & 3 & 3 & & \\
+Validation & 3 & 3 & 3 & \\
 \hline
-Safety analyses & 2 & 2 & & \\
+Safety analyses & 2 & 2 & 2 & \\
 \hline
 \end{tabular}
 
@@ -140,7 +140,7 @@ Formal language & 3 & 3 & 3 &  \\
 \hline
 Structured language & 3 & 3 & 3 & \\
 \hline
-Modular language & 3 & 2 & * & \\
+Modular language & 3 & 2 & - & \\
 \hline
 Textual language & 0 & 3 & 1 & \\
 \hline
@@ -604,7 +604,11 @@ The tool is not design to generate test, however we can imagine means to  genera
 \end{author_comment}
 
 \begin{assessor2}
-There exist literature regarding test generation based on Event-B models, for example \url{http://deploy-eprints.ecs.soton.ac.uk/349/13/multiobj_testop.pdf}. Furthermore, a MBT plugin exists for Rodin, \see{http://wiki.event-b.org/index.php/MBT_plugin}.
+  There exist literature regarding test generation based on Event-B
+  models, for example
+  \url{http://deploy-eprints.ecs.soton.ac.uk/349/13/multiobj_testop.pdf}. Furthermore,
+  a MBT plugin exists for Rodin,
+  \url{http://wiki.event-b.org/index.php/MBT_plugin}.
 \end{assessor2}
 
 \paragraph{Simulation, execution, debugging}


### PR DESCRIPTION
Hello,

I added the assessment for Event-B and Rodin. 

Name: Assessment for Event-B and Rodin added
Description: Assessment of the 2nd assessor for Event-B and Rodin
Gist URL: -
Cryptography: No
Author(s): Self

I hereby declare that I accept to contribute following the openETCS terms of use and the openETCS IP policy.

http://openetcs.org/termsofuse

https://github.com/openETCS/ecosystem/wiki/IP-Policy
