### PR TITLE
Fixed #260

### DIFF
--- a/tool/bundles/org.openetcs.product/build.properties
+++ b/tool/bundles/org.openetcs.product/build.properties
@@ -2,5 +2,4 @@ bin.includes = META-INF/,\
                plugin_customization.ini,\
                plugin.xml,\
                splash.bmp,\
-               splash.xcf,\
-               OSGI-INF/
+               splash.xcf


### PR DESCRIPTION
###### ### SNIP

Name: Fix for #260
Description: Removed OSGI-INF entry from build.properties
Gist URL: 
Cryptography: No
Author(s): Self
I hereby declare that I accept to contribute following the openETCS terms of use and the openETCS IP policy.

http://openetcs.org/termsofuse

https://github.com/openETCS/ecosystem/wiki/IP-Policy
###### ### SNAP
